### PR TITLE
Batasi penulisan roster ke RTDB untuk UID tertentu

### DIFF
--- a/schedule.js
+++ b/schedule.js
@@ -1,11 +1,11 @@
 // =============================
-// schedule.js (FINAL - UID diambil dari RTDB config)
+// schedule.js (FINAL - UID ditetapkan di variabel ALLOWED_UID)
 // =============================
 
 // Wajib: type="module" di HTML
 import { requireAuth, getFirebase } from "./auth-guard.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
-import { getDatabase, ref, set, get } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
+import { getDatabase, ref, set } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
 
 const { app, auth } = getFirebase();
 const db = getDatabase(app);
@@ -14,8 +14,9 @@ const db = getDatabase(app);
 // Ganti dengan URL Cloudflare Worker kamu (bkn URL Apps Script langsung)
 const PROXY_ENDPOINT = "https://roster-proxy.avsecbwx2018.workers.dev"; // <-- ganti ini
 const SHARED_TOKEN   = "N45p"; // samakan dgn code.gs
+const ALLOWED_UID = "XrSOg13vcDM2npZYK9vxekbmQih2"; // UID yang diperbolehkan menulis ke "roster"
 
-// UID akun yang boleh menulis ke "roster" disimpan di RTDB pada path "config/UID-NOVAN"
+// UID akun yang boleh menulis ke "roster" ditetapkan pada variabel ALLOWED_UID
 
 
 // ====== DOM utils & overlay ======
@@ -157,12 +158,10 @@ async function init(){
         if (!user) throw new Error("User belum login");
 
         const uid = user.uid;
-        const allowedSnap = await get(ref(db, "config/UID-NOVAN"));
-        const allowedUid = allowedSnap.val();
         console.log("🔑 UID login saat ini:", uid);
-        console.log("✅ UID yang diizinkan:", allowedUid);
+        console.log("✅ UID yang diizinkan:", ALLOWED_UID);
 
-        if (uid === allowedUid) {
+        if (uid === ALLOWED_UID) {
           // ✅ sesuai rules: hanya UID ini yang bisa menulis
           // Simpan hanya data roster sesuai struktur RTDB
           await set(ref(db, "roster"), classified);

--- a/schedule.js
+++ b/schedule.js
@@ -1,11 +1,11 @@
 // =============================
-// schedule.js (FINAL - pakai UID untuk rules RTDB)
+// schedule.js (FINAL - UID diambil dari RTDB config)
 // =============================
 
 // Wajib: type="module" di HTML
 import { requireAuth, getFirebase } from "./auth-guard.js";
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
-import { getDatabase, ref, set } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
+import { getDatabase, ref, set, get } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
 
 const { app, auth } = getFirebase();
 const db = getDatabase(app);
@@ -15,8 +15,8 @@ const db = getDatabase(app);
 const PROXY_ENDPOINT = "https://roster-proxy.avsecbwx2018.workers.dev"; // <-- ganti ini
 const SHARED_TOKEN   = "N45p"; // samakan dgn code.gs
 
-// UID akun Firebase Authentication yang diizinkan menulis ke RTDB (path "roster")
-const UID_NOVAN = "XrSOg13vcDM2npZYK9vxekbmQih2";
+// UID akun yang boleh menulis ke "roster" disimpan di RTDB pada path "config/UID-NOVAN"
+
 
 // ====== DOM utils & overlay ======
 function $(sel){ return document.querySelector(sel); }
@@ -157,10 +157,12 @@ async function init(){
         if (!user) throw new Error("User belum login");
 
         const uid = user.uid;
+        const allowedSnap = await get(ref(db, "config/UID-NOVAN"));
+        const allowedUid = allowedSnap.val();
         console.log("🔑 UID login saat ini:", uid);
-        console.log("✅ UID yang diizinkan:", UID_NOVAN);
+        console.log("✅ UID yang diizinkan:", allowedUid);
 
-        if (uid === UID_NOVAN) {
+        if (uid === allowedUid) {
           // ✅ sesuai rules: hanya UID ini yang bisa menulis
           // Simpan hanya data roster sesuai struktur RTDB
           await set(ref(db, "roster"), classified);

--- a/schedule.js
+++ b/schedule.js
@@ -16,7 +16,8 @@ const PROXY_ENDPOINT = "https://roster-proxy.avsecbwx2018.workers.dev"; // <-- g
 const SHARED_TOKEN   = "N45p"; // samakan dgn code.gs
 
 // UID yang diizinkan menulis roster (ganti dengan UID akunmu dari Firebase Console)
-const ALLOWED_UID = "XrSOg13vcDM2npZYK9vxekbmQih2";
+// Sesuaikan dengan rules RTDB yang hanya memperbolehkan satu UID.
+const ALLOWED_UID = "UID-NOVAN";
 
 // ====== DOM utils & overlay ======
 function $(sel){ return document.querySelector(sel); }
@@ -162,10 +163,8 @@ async function init(){
 
         if (uid === ALLOWED_UID) {
           // ✅ sesuai rules: hanya UID ini yang bisa menulis
-          await set(ref(db, "roster"), {
-            uid,
-            roster: classified
-          });
+          // Simpan hanya data roster sesuai struktur RTDB
+          await set(ref(db, "roster"), classified);
           Modal.show("Roster sudah terkirim ke RTDB");
         } else {
           console.warn("Akun tidak diizinkan kirim roster", { uid });

--- a/schedule.js
+++ b/schedule.js
@@ -15,9 +15,8 @@ const db = getDatabase(app);
 const PROXY_ENDPOINT = "https://roster-proxy.avsecbwx2018.workers.dev"; // <-- ganti ini
 const SHARED_TOKEN   = "N45p"; // samakan dgn code.gs
 
-// UID yang diizinkan menulis roster (ganti dengan UID akunmu dari Firebase Console)
-// Sesuaikan dengan rules RTDB yang hanya memperbolehkan satu UID.
-const ALLOWED_UID = "UID-NOVAN";
+// UID akun Firebase Authentication yang diizinkan menulis ke RTDB (path "roster")
+const ALLOWED_UID = "XrSOg13vcDM2npZYK9vxekbmQih2";
 
 // ====== DOM utils & overlay ======
 function $(sel){ return document.querySelector(sel); }

--- a/schedule.js
+++ b/schedule.js
@@ -16,7 +16,7 @@ const PROXY_ENDPOINT = "https://roster-proxy.avsecbwx2018.workers.dev"; // <-- g
 const SHARED_TOKEN   = "N45p"; // samakan dgn code.gs
 
 // UID akun Firebase Authentication yang diizinkan menulis ke RTDB (path "roster")
-const ALLOWED_UID = "XrSOg13vcDM2npZYK9vxekbmQih2";
+const UID_NOVAN = "XrSOg13vcDM2npZYK9vxekbmQih2";
 
 // ====== DOM utils & overlay ======
 function $(sel){ return document.querySelector(sel); }
@@ -158,9 +158,9 @@ async function init(){
 
         const uid = user.uid;
         console.log("🔑 UID login saat ini:", uid);
-        console.log("✅ UID yang diizinkan:", ALLOWED_UID);
+        console.log("✅ UID yang diizinkan:", UID_NOVAN);
 
-        if (uid === ALLOWED_UID) {
+        if (uid === UID_NOVAN) {
           // ✅ sesuai rules: hanya UID ini yang bisa menulis
           // Simpan hanya data roster sesuai struktur RTDB
           await set(ref(db, "roster"), classified);


### PR DESCRIPTION
## Ringkasan
- Tambahkan konstanta `ALLOWED_UID` pada `schedule.js` untuk membatasi penulisan roster hanya oleh akun tertentu
- Validasi UID dan kirim data roster dari spreadsheet ke Realtime Database sesuai struktur rules

## Pengujian
- `npm test` *(gagal: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abe7660a3483298eaf5d1d4249babf