### PR TITLE
Sync roster personnel for plotting

### DIFF
--- a/plotting.html
+++ b/plotting.html
@@ -59,18 +59,12 @@
     <tbody id="assignRows"></tbody>
   </table>
 
-  <!-- Kelola Personil -->
-  <div class="manage" aria-label="Kelola Personil">
-    <h2>Kelola Personil</h2>
-    <div class="add-person">
-      <input id="nameInput" type="text" placeholder="Nama" />
-      <label><input type="checkbox" id="seniorSpec" /> Senior</label>
-      <label><input type="checkbox" id="juniorSpec" /> Junior</label>
-      <label><input type="checkbox" id="basicSpec" /> Basic</label>
-      <button id="addPersonBtn" type="button">Tambah</button>
-    </div>
+    <!-- Kelola Personil -->
+    <div class="manage" aria-label="Kelola Personil">
+      <h2>Kelola Personil</h2>
+      <p class="auto-note">Daftar personil diambil otomatis dari roster.</p>
 
-    <table class="people" aria-label="Daftar Personil">
+      <table class="people" aria-label="Daftar Personil">
       <thead>
         <tr><th>Nama</th><th>Senior</th><th>Junior</th><th>Basic</th><th>Aksi</th></tr>
       </thead>


### PR DESCRIPTION
## Summary
- Populate site people from RTDB `roster` entries
- Map roster names to user specs to drive rotation logic
- Remove manual personnel input from plotting view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acefbf8f6083298798c248efbc44ed