### PR TITLE
Disable capture button when not in landscape orientation

### DIFF
--- a/random.js
+++ b/random.js
@@ -25,6 +25,22 @@ const tindakanField=tindakanSel?.parentElement,tipePiField=tipePiSel?.parentElem
 const isiBarangInp=$("#isiBarang");
 const fotoBtn=$("#fotoBtn"),fotoInput=$("#fotoInput"),fotoPreview=$("#fotoPreview");
 
+const captureBtn = document.querySelector("#fotoBtn"); // sesuaikan ID bila berbeda
+
+function checkOrientation() {
+  const isLandscape =
+    (screen.orientation && screen.orientation.type.startsWith("landscape")) ||
+    Math.abs(window.orientation || 0) === 90;
+  captureBtn.disabled = !isLandscape;
+  if (!isLandscape) {
+    showAlert("Handphone harus posisi horizontal");
+  }
+}
+
+window.addEventListener("orientationchange", checkOrientation);
+document.addEventListener("DOMContentLoaded", checkOrientation);
+
+
 // SUSPECT HBSCP
 const bagasiCard=$("#bagasiCard"),bagasiListCard=$("#bagasiListCard"),bagasiToggle=$("#bagasiToggle"),bagasiContent=$("#bagasiContent");
 const scanBagBtn=$("#scanBagBtn");


### PR DESCRIPTION
## Summary
- Disable capture button if device orientation is not landscape
- Alert users to rotate device horizontally
- Listen for orientation changes and DOM ready to enforce orientation check

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dc0673a88329ba139c9ab2262a5d