### PR TITLE
Add SIDS display page

### DIFF
--- a/SIDS.css
+++ b/SIDS.css
@@ -1,23 +1,35 @@
 body{
   margin:0;
-  background:#000;
+  background:linear-gradient(#000,#111);
   color:#fff;
   font-family:Arial, sans-serif;
   font-weight:bold;
 }
 
-.logo{
-  position:absolute;
-  top:10px;
-  height:80px;
+header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:10px 20px;
+  background:#800000;
+  border-bottom:4px solid #FFD700;
 }
-.logo-left{ left:20px; }
-.logo-right{ right:20px; }
+header img{ height:80px; }
+header h1{
+  flex:1;
+  text-align:center;
+  color:#FFD700;
+  font-size:3vw;
+  margin:0;
+}
 
 #sidsTable{
   width:100%;
   border-collapse:collapse;
-  margin-top:110px;
+  margin:20px auto;
+  background:#111;
+  box-shadow:0 0 20px rgba(0,0,0,0.7);
+  border:4px solid #FFD700;
 }
 #sidsTable thead{ background:#800000; }
 #sidsTable th, #sidsTable td{
@@ -26,7 +38,7 @@ body{
   text-align:center;
   border-bottom:2px solid #FFD700;
 }
-#sidsTable tbody tr:nth-child(even){ background:#111; }
+#sidsTable tbody tr:nth-child(even){ background:#222; }
 
 .ticker{
   position:fixed;

--- a/SIDS.css
+++ b/SIDS.css
@@ -1,0 +1,48 @@
+body{
+  margin:0;
+  background:#000;
+  color:#fff;
+  font-family:Arial, sans-serif;
+  font-weight:bold;
+}
+
+.logo{
+  position:absolute;
+  top:10px;
+  height:80px;
+}
+.logo-left{ left:20px; }
+.logo-right{ right:20px; }
+
+#sidsTable{
+  width:100%;
+  border-collapse:collapse;
+  margin-top:110px;
+}
+#sidsTable thead{ background:#800000; }
+#sidsTable th, #sidsTable td{
+  padding:20px 10px;
+  font-size:2vw;
+  text-align:center;
+  border-bottom:2px solid #FFD700;
+}
+#sidsTable tbody tr:nth-child(even){ background:#111; }
+
+.ticker{
+  position:fixed;
+  bottom:0;
+  width:100%;
+  background:#800000;
+  color:#fff;
+  overflow:hidden;
+  border-top:2px solid #FFD700;
+}
+.ticker div{
+  display:inline-block;
+  padding-left:100%;
+  animation:scroll 20s linear infinite;
+  white-space:nowrap;
+}
+@keyframes scroll{
+  from{transform:translateX(0);}to{transform:translateX(-100%);}
+}

--- a/SIDS.html
+++ b/SIDS.html
@@ -6,11 +6,14 @@
   <title>PEMERIKSAAN BAGASI TERCATAT</title>
   <link rel="stylesheet" href="SIDS.css" />
 </head>
-<body>
-  <img src="logobwx.png" alt="BWX" class="logo logo-left" />
-  <img src="logoapindo.png" alt="APINDO" class="logo logo-right" />
+  <body>
+    <header>
+      <img src="logobwx.png" alt="BWX" />
+      <h1 id="pageTitle">PEMERIKSAAN BAGASI TERCATAT</h1>
+      <img src="logoapindo.png" alt="APINDO" />
+    </header>
 
-  <table id="sidsTable">
+    <table id="sidsTable">
     <thead>
       <tr>
         <th id="thTime">WAKTU</th>

--- a/SIDS.html
+++ b/SIDS.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SIDS Board</title>
+  <link rel="stylesheet" href="SIDS.css" />
+</head>
+<body>
+  <img src="logobwx.png" alt="BWX" class="logo logo-left" />
+  <img src="logoapindo.png" alt="APINDO" class="logo logo-right" />
+
+  <table id="sidsTable">
+    <thead>
+      <tr><th>TIME</th><th>PASSENGER</th><th>FLIGHT</th><th>STATUS</th></tr>
+    </thead>
+    <tbody id="sidsBody"></tbody>
+  </table>
+
+  <div class="ticker"><div id="tickerText">INFORMASI KEAMANAN BANDARA</div></div>
+
+  <script type="module" src="SIDS.js"></script>
+</body>
+</html>

--- a/SIDS.html
+++ b/SIDS.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SIDS Board</title>
+  <title>PEMERIKSAAN BAGASI TERCATAT</title>
   <link rel="stylesheet" href="SIDS.css" />
 </head>
 <body>
@@ -12,7 +12,12 @@
 
   <table id="sidsTable">
     <thead>
-      <tr><th>TIME</th><th>PASSENGER</th><th>FLIGHT</th><th>STATUS</th></tr>
+      <tr>
+        <th id="thTime">WAKTU</th>
+        <th id="thPassenger">PENUMPANG</th>
+        <th id="thFlight">PENERBANGAN</th>
+        <th id="thStatus">STATUS</th>
+      </tr>
     </thead>
     <tbody id="sidsBody"></tbody>
   </table>

--- a/SIDS.js
+++ b/SIDS.js
@@ -86,6 +86,8 @@ function applyTranslations(){
   const t = translations[currentLang];
   document.title = t.title;
   document.documentElement.lang = currentLang;
+  const pageTitleEl = document.getElementById('pageTitle');
+  if(pageTitleEl) pageTitleEl.textContent = t.title;
   const headCells = [
     document.getElementById('thTime'),
     document.getElementById('thPassenger'),

--- a/SIDS.js
+++ b/SIDS.js
@@ -1,0 +1,67 @@
+const SHARED_TOKEN = "N45p";
+const LOOKUP_URL = "https://rdcheck.avsecbwx2018.workers.dev/";
+
+const flightTimes = {};
+
+function formatWib(timeStr){
+  const m = String(timeStr || "").match(/(\d{1,2}):(\d{2})/);
+  if(m){
+    const h = m[1].padStart(2,"0");
+    const mm = m[2].padStart(2,"0");
+    return `${h}:${mm} WIB`;
+  }
+  return String(timeStr||"");
+}
+
+async function loadFlightTimes(){
+  if(Object.keys(flightTimes).length) return;
+  try{
+    const url = `${LOOKUP_URL}?action=flight_update&token=${encodeURIComponent(SHARED_TOKEN)}`;
+    const r = await fetch(url,{method:"GET",mode:"cors"});
+    const j = await r.json().catch(()=>({}));
+    if(j?.ok && Array.isArray(j.rows)){
+      j.rows.forEach(it=>{
+        const fl = (it.flight||"").toUpperCase();
+        const tm = formatWib(it.departure||it.dep||it.time||it.jam||"");
+        if(fl) flightTimes[fl]=tm;
+      });
+    }
+  }catch(err){ console.error(err); }
+}
+
+function renderList(rows){
+  const body = document.getElementById('sidsBody');
+  if(!body) return;
+  body.innerHTML='';
+  rows.forEach(it=>{
+    const norm={};
+    for(const k in it){
+      norm[k.replace(/[^a-z0-9]/gi,'').toLowerCase()] = it[k];
+    }
+    const aksi=(norm.aksi||norm.action||'').trim();
+    if(!aksi) return; // remove if aksi empty
+
+    const passenger = (norm.namapemilik||norm.nama||'-').toUpperCase();
+    const flight = (norm.flight||'-').toUpperCase();
+    const time = flightTimes[flight] || '-';
+
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${time}</td><td>${passenger}</td><td>${flight}</td><td>DIPERIKSA HARAP MENGHUBUNGI PETUGAS</td>`;
+    body.appendChild(tr);
+  });
+}
+
+async function loadSuspectList(){
+  try{
+    await loadFlightTimes();
+    const url = `${LOOKUP_URL}?action=list_suspect&token=${encodeURIComponent(SHARED_TOKEN)}&limit=200`;
+    const r = await fetch(url,{method:"GET",mode:"cors"});
+    const j = await r.json().catch(()=>({}));
+    if(j?.ok && Array.isArray(j.rows)) renderList(j.rows);
+  }catch(err){ console.error(err); }
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+  loadSuspectList();
+  setInterval(loadSuspectList,30000);
+});


### PR DESCRIPTION
## Summary
- Add SIDS.html, SIDS.css, and SIDS.js for a TV-friendly board displaying passengers requiring follow-up
- Fetch suspect list using existing lookup endpoint and hide entries without actions
- Auto-refresh list every 30 seconds with running ticker and branding logos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ea732ebc83299a9d9d4130058db8