### PR TITLE
Fix suspect list filtering

### DIFF
--- a/random.js
+++ b/random.js
@@ -278,11 +278,12 @@ function renderSuspectList(rows){
       const nk=k.replace(/[^a-z0-9]/gi,"").toLowerCase();
       norm[nk]=it[k];
     }
+    // tampilkan hanya baris yang sudah memiliki aksi
     const aksi=(norm.aksi||norm.action||"").trim();
-    if(aksi) return;
+    if(!aksi) return;
 
     const bagNo  = norm.bagno || norm.nomorbagasi || norm.nobagasi || "-";
-    const rowItems = Number(it.rowItems || it.rowitems || 0);
+    const rowItems = Number(norm.rowitems || 0);
     const flight = norm.flight || "-";
     const dest   = norm.tujuan || "-";
     const dep    = flightTimes[flight.toUpperCase()] || "-";


### PR DESCRIPTION
## Summary
- render only suspect rows that include an action
- normalize row item lookup in list rendering

## Testing
- `node --check random.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3f001e6ec8329a3858adee9e3bb07