### PR TITLE
Style SIDS board with maroon and gold theme

### DIFF
--- a/SIDS.css
+++ b/SIDS.css
@@ -1,6 +1,6 @@
 body{
   margin:0;
-  background:linear-gradient(#000,#111);
+  background:#800000;
   color:#fff;
   font-family:Arial, sans-serif;
   font-weight:bold;
@@ -13,6 +13,16 @@ header{
   padding:10px 20px;
   background:#800000;
   border-bottom:4px solid #FFD700;
+}
+.header-left{
+  display:flex;
+  align-items:center;
+  gap:10px;
+}
+.suitcase-icon{
+  width:50px;
+  height:50px;
+  fill:#FFD700;
 }
 header img{ height:80px; }
 header h1{
@@ -27,25 +37,28 @@ header h1{
   width:100%;
   border-collapse:collapse;
   margin:20px auto;
-  background:#111;
+  background:#800000;
   box-shadow:0 0 20px rgba(0,0,0,0.7);
   border:4px solid #FFD700;
 }
-#sidsTable thead{ background:#800000; }
+#sidsTable thead{
+  background:#800000;
+  color:#FFD700;
+}
 #sidsTable th, #sidsTable td{
   padding:20px 10px;
   font-size:2vw;
   text-align:center;
   border-bottom:2px solid #FFD700;
 }
-#sidsTable tbody tr:nth-child(even){ background:#222; }
+#sidsTable tbody tr:nth-child(even){ background:#000; }
 
 .ticker{
   position:fixed;
   bottom:0;
   width:100%;
   background:#800000;
-  color:#fff;
+  color:#FFD700;
   overflow:hidden;
   border-top:2px solid #FFD700;
 }
@@ -58,3 +71,20 @@ header h1{
 @keyframes scroll{
   from{transform:translateX(0);}to{transform:translateX(-100%);}
 }
+
+.logo-bottom-left{
+  position:fixed;
+  bottom:60px;
+  left:20px;
+  height:80px;
+}
+
+.clock{
+  position:fixed;
+  bottom:60px;
+  right:20px;
+  text-align:right;
+  color:#FFD700;
+}
+#clockTime{ font-size:2vw; }
+#clockDate{ font-size:1vw; }


### PR DESCRIPTION
## Summary
- Restyle SIDS display to use maroon background with gold accents
- Add layout rules for header icon, clock, and bottom logo
- Update ticker and table styling, alternating black rows for readability

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f66a02cc8329abb792a1116b580c