### PR TITLE
feat: add check page with photo capture

### DIFF
--- a/check.css
+++ b/check.css
@@ -7,16 +7,35 @@
   margin-bottom:12px;
 }
 
-.icon-preview{
-  display:flex;
-  gap:12px;
-  align-items:center;
+select{
+  width:100%;
+  background:#0b1324;
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:12px;
+}
+
+.subcard{
   margin-bottom:12px;
 }
-.icon-preview img{
-  width:64px;
-  height:64px;
+
+.full-img{
+  width:100%;
+  height:auto;
   object-fit:contain;
   border-radius:12px;
   border:1px solid var(--border);
+}
+
+.grid-checks{
+  display:grid;
+  grid-template-columns:repeat(4,1fr);
+  gap:8px;
+}
+
+.grid-checks label{
+  display:flex;
+  align-items:center;
+  gap:4px;
 }

--- a/check.css
+++ b/check.css
@@ -1,0 +1,22 @@
+@import url('./lb_all.css');
+
+.row-3{
+  display:grid;
+  grid-template-columns:1fr 1fr 1fr;
+  gap:clamp(8px,2vw,12px);
+  margin-bottom:12px;
+}
+
+.icon-preview{
+  display:flex;
+  gap:12px;
+  align-items:center;
+  margin-bottom:12px;
+}
+.icon-preview img{
+  width:64px;
+  height:64px;
+  object-fit:contain;
+  border-radius:12px;
+  border:1px solid var(--border);
+}

--- a/check.css
+++ b/check.css
@@ -30,3 +30,26 @@
   align-items:center;
   gap:4px;
 }
+
+.check-table{
+  width:100%;
+  border-collapse:collapse;
+  margin-bottom:12px;
+}
+
+.check-table th,
+.check-table td{
+  border:1px solid var(--border);
+  padding:4px;
+  text-align:center;
+}
+
+.check-table th:first-child,
+.check-table td:first-child{
+  text-align:left;
+}
+
+.label-text{
+  font-weight:600;
+  margin-bottom:12px;
+}

--- a/check.css
+++ b/check.css
@@ -7,15 +7,6 @@
   margin-bottom:12px;
 }
 
-select{
-  width:100%;
-  background:#0b1324;
-  color:var(--text);
-  border:1px solid var(--border);
-  border-radius:12px;
-  padding:12px;
-}
-
 .subcard{
   margin-bottom:12px;
 }

--- a/check.html
+++ b/check.html
@@ -48,9 +48,6 @@
           <div id="uploadName2" class="muted"></div>
         </div>
       </div>
-      <div class="field">
-        <select id="selectNilai"></select>
-      </div>
     </section>
 
     <!-- Card 3: Icons and Submit -->

--- a/check.html
+++ b/check.html
@@ -30,12 +30,8 @@
     <!-- Card 2: Foto dan Nilai -->
     <section class="card">
       <h1 class="card-title">Dokumentasi</h1>
-      <div class="row-2">
-        <button id="photoBtn1" class="btn" type="button">Ambil Foto 1</button>
-        <button id="photoBtn2" class="btn" type="button">Ambil Foto 2</button>
-        <input id="fileInput1" type="file" accept="image/*" capture="environment" class="hidden" />
-        <input id="fileInput2" type="file" accept="image/*" capture="environment" class="hidden" />
-      </div>
+      <button id="photoBtn1" class="btn" type="button">Ambil Foto 1</button>
+      <input id="fileInput1" type="file" accept="image/*" capture="environment" class="hidden" />
       <div id="uploadInfo1" class="upload-info hidden">
         <img id="preview1" alt="Preview 1" />
         <div class="meta">
@@ -43,6 +39,8 @@
           <div id="uploadName1" class="muted"></div>
         </div>
       </div>
+      <button id="photoBtn2" class="btn" type="button">Ambil Foto 2</button>
+      <input id="fileInput2" type="file" accept="image/*" capture="environment" class="hidden" />
       <div id="uploadInfo2" class="upload-info hidden">
         <img id="preview2" alt="Preview 2" />
         <div class="meta">
@@ -51,18 +49,21 @@
         </div>
       </div>
       <div class="field">
-        <label for="selectNilai">Nilai</label>
         <select id="selectNilai"></select>
       </div>
     </section>
 
     <!-- Card 3: Icons and Submit -->
     <section class="card">
-      <h1 class="card-title">Ikon</h1>
-      <div class="icon-preview">
-        <img id="icon1" alt="Icon 1" />
-        <img id="icon2" alt="Icon 2" />
+      <h1 class="card-title">STP</h1>
+      <div class="card subcard">
+        <img src="icons/stp1.png" alt="STP 1" class="full-img" />
       </div>
+      <div id="checks1" class="card subcard grid-checks"></div>
+      <div class="card subcard">
+        <img src="icons/stp2.png" alt="STP 2" class="full-img" />
+      </div>
+      <div id="checks2" class="card subcard grid-checks"></div>
       <button id="submitBtn" class="btn primary full" type="button">Kirim</button>
     </section>
   </main>

--- a/check.html
+++ b/check.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Check</title>
+  <link rel="stylesheet" href="check.css" />
+</head>
+<body>
+  <div class="app-bar">
+    <a class="back-btn" aria-label="Kembali" href="index.html">
+      <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M15 6L9 12L15 18"></path>
+      </svg>
+    </a>
+    <h1 class="app-title">Check</h1>
+  </div>
+
+  <main class="container">
+    <!-- Card 1: Jenis -->
+    <section class="card">
+      <h1 class="card-title">Jenis Check</h1>
+      <div class="row-3">
+        <button id="btnSTP" class="btn type-btn" type="button">STP</button>
+        <button id="btnOTP" class="btn type-btn" type="button">OTP</button>
+        <button id="btnHHMD" class="btn type-btn" type="button">HHMD/ETD</button>
+      </div>
+    </section>
+
+    <!-- Card 2: Foto dan Nilai -->
+    <section class="card">
+      <h1 class="card-title">Dokumentasi</h1>
+      <div class="row-2">
+        <button id="photoBtn1" class="btn" type="button">Ambil Foto 1</button>
+        <button id="photoBtn2" class="btn" type="button">Ambil Foto 2</button>
+        <input id="fileInput1" type="file" accept="image/*" capture="environment" class="hidden" />
+        <input id="fileInput2" type="file" accept="image/*" capture="environment" class="hidden" />
+      </div>
+      <div id="uploadInfo1" class="upload-info hidden">
+        <img id="preview1" alt="Preview 1" />
+        <div class="meta">
+          <div id="uploadStatus1">Menunggu foto…</div>
+          <div id="uploadName1" class="muted"></div>
+        </div>
+      </div>
+      <div id="uploadInfo2" class="upload-info hidden">
+        <img id="preview2" alt="Preview 2" />
+        <div class="meta">
+          <div id="uploadStatus2">Menunggu foto…</div>
+          <div id="uploadName2" class="muted"></div>
+        </div>
+      </div>
+      <div class="field">
+        <label for="selectNilai">Nilai</label>
+        <select id="selectNilai"></select>
+      </div>
+    </section>
+
+    <!-- Card 3: Icons and Submit -->
+    <section class="card">
+      <h1 class="card-title">Ikon</h1>
+      <div class="icon-preview">
+        <img id="icon1" alt="Icon 1" />
+        <img id="icon2" alt="Icon 2" />
+      </div>
+      <button id="submitBtn" class="btn primary full" type="button">Kirim</button>
+    </section>
+  </main>
+
+  <!-- Overlay -->
+  <div id="overlay" class="overlay hidden" role="dialog" aria-modal="true">
+    <div class="sheet" role="document">
+      <div class="icon spinner"></div>
+      <div class="texts">
+        <div class="title">Memproses…</div>
+        <div class="desc">Mohon tunggu</div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="check.js"></script>
+</body>
+</html>

--- a/check.html
+++ b/check.html
@@ -19,7 +19,6 @@
   <main class="container">
     <!-- Card 1: Jenis -->
     <section class="card">
-      <h1 class="card-title">Jenis Check</h1>
       <div class="row-3">
         <button id="btnSTP" class="btn type-btn" type="button">STP</button>
         <button id="btnOTP" class="btn type-btn" type="button">OTP</button>
@@ -27,9 +26,8 @@
       </div>
     </section>
 
-    <!-- Card 2: Foto dan Nilai -->
+    <!-- Card 2: Foto -->
     <section class="card">
-      <h1 class="card-title">Dokumentasi</h1>
       <button id="photoBtn1" class="btn" type="button">Ambil Foto 1</button>
       <input id="fileInput1" type="file" accept="image/*" capture="environment" class="hidden" />
       <div id="uploadInfo1" class="upload-info hidden">
@@ -50,9 +48,8 @@
       </div>
     </section>
 
-    <!-- Card 3: Icons and Submit -->
+    <!-- Card 3: Icons -->
     <section class="card">
-      <h1 class="card-title">STP</h1>
       <div class="card subcard">
         <img src="icons/stp1.png" alt="STP 1" class="full-img" />
       </div>
@@ -61,6 +58,62 @@
         <img src="icons/stp2.png" alt="STP 2" class="full-img" />
       </div>
       <div id="checks2" class="card subcard grid-checks"></div>
+    </section>
+
+    <!-- Card 4: Tabel Kalibrasi -->
+    <section class="card">
+      <table class="check-table">
+        <thead>
+          <tr>
+            <th>POSISI TEST</th>
+            <th>TIPE<br/>KNIFE 304</th>
+            <th>HASIL TEST<br/>centang=Alarm<br/>Kosong=No Alarm</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Lengan Kanan</td>
+            <td>IN</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td>Bagian Dalam</td>
+            <td>OUT</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td>Pinggang Kanan</td>
+            <td>IN</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td>OUT</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td>Pinggang Belakang</td>
+            <td>IN</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td>Bagian Tengah</td>
+            <td>OUT</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td>Pergelangan Kaki</td>
+            <td>IN</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+          <tr>
+            <td>Bagian Kanan</td>
+            <td>OUT</td>
+            <td><input type="checkbox" /></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="label-text">HASIL KALIBRASI</div>
       <button id="submitBtn" class="btn primary full" type="button">Kirim</button>
     </section>
   </main>

--- a/check.js
+++ b/check.js
@@ -1,0 +1,68 @@
+// Interaksi untuk halaman check
+
+function setupPhoto(btnId, inputId, previewId, infoId, statusId, nameId){
+  const btn = document.getElementById(btnId);
+  const input = document.getElementById(inputId);
+  const preview = document.getElementById(previewId);
+  const info = document.getElementById(infoId);
+  const status = document.getElementById(statusId);
+  const name = document.getElementById(nameId);
+
+  btn.addEventListener('click', () => input.click());
+  input.addEventListener('change', () => {
+    const file = input.files[0];
+    if(!file) return;
+    preview.src = URL.createObjectURL(file);
+    status.textContent = 'Foto siap diunggah';
+    name.textContent = file.name;
+    info.classList.remove('hidden');
+  });
+}
+
+function initDropdown(){
+  const opts = ['Baik','Rusak','Perlu Perbaikan'];
+  const sel = document.getElementById('selectNilai');
+  sel.innerHTML = '<option value="">Pilih nilai…</option>';
+  opts.forEach(v => {
+    const o = document.createElement('option');
+    o.value = v; o.textContent = v; sel.appendChild(o);
+  });
+}
+
+function initIcons(){
+  const params = new URLSearchParams(location.search);
+  const img1 = params.get('img1') || 'logobwx.png';
+  const img2 = params.get('img2') || 'logodju.png';
+  document.getElementById('icon1').src = `icons/${img1}`;
+  document.getElementById('icon2').src = `icons/${img2}`;
+}
+
+function initTypeButtons(){
+  const buttons = document.querySelectorAll('.type-btn');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      buttons.forEach(b => b.classList.remove('primary'));
+      btn.classList.add('primary');
+    });
+  });
+}
+
+function initSubmit(){
+  const overlay = document.getElementById('overlay');
+  document.getElementById('submitBtn').addEventListener('click', () => {
+    overlay.classList.remove('hidden');
+    setTimeout(() => {
+      overlay.classList.add('hidden');
+      alert('Data terkirim');
+    }, 1000);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupPhoto('photoBtn1','fileInput1','preview1','uploadInfo1','uploadStatus1','uploadName1');
+  setupPhoto('photoBtn2','fileInput2','preview2','uploadInfo2','uploadStatus2','uploadName2');
+  initDropdown();
+  initIcons();
+  initTypeButtons();
+  initSubmit();
+});

--- a/check.js
+++ b/check.js
@@ -19,16 +19,6 @@ function setupPhoto(btnId, inputId, previewId, infoId, statusId, nameId){
   });
 }
 
-function initDropdown(){
-  const opts = ['Baik','Rusak','Perlu Perbaikan'];
-  const sel = document.getElementById('selectNilai');
-  sel.innerHTML = '<option value="">Pilih nilai…</option>';
-  opts.forEach(v => {
-    const o = document.createElement('option');
-    o.value = v; o.textContent = v; sel.appendChild(o);
-  });
-}
-
 function initTypeButtons(){
   const buttons = document.querySelectorAll('.type-btn');
   buttons.forEach(btn => {
@@ -67,7 +57,6 @@ function populateChecks(id){
 document.addEventListener('DOMContentLoaded', () => {
   setupPhoto('photoBtn1','fileInput1','preview1','uploadInfo1','uploadStatus1','uploadName1');
   setupPhoto('photoBtn2','fileInput2','preview2','uploadInfo2','uploadStatus2','uploadName2');
-  initDropdown();
   initTypeButtons();
   initSubmit();
   populateChecks('checks1');

--- a/check.js
+++ b/check.js
@@ -29,14 +29,6 @@ function initDropdown(){
   });
 }
 
-function initIcons(){
-  const params = new URLSearchParams(location.search);
-  const img1 = params.get('img1') || 'logobwx.png';
-  const img2 = params.get('img2') || 'logodju.png';
-  document.getElementById('icon1').src = `icons/${img1}`;
-  document.getElementById('icon2').src = `icons/${img2}`;
-}
-
 function initTypeButtons(){
   const buttons = document.querySelectorAll('.type-btn');
   buttons.forEach(btn => {
@@ -58,11 +50,26 @@ function initSubmit(){
   });
 }
 
+function populateChecks(id){
+  const wrap = document.getElementById(id);
+  for(let i=1;i<=36;i++){
+    const label = document.createElement('label');
+    const span = document.createElement('span');
+    span.textContent = i;
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    label.appendChild(span);
+    label.appendChild(cb);
+    wrap.appendChild(label);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   setupPhoto('photoBtn1','fileInput1','preview1','uploadInfo1','uploadStatus1','uploadName1');
   setupPhoto('photoBtn2','fileInput2','preview2','uploadInfo2','uploadStatus2','uploadName2');
   initDropdown();
-  initIcons();
   initTypeButtons();
   initSubmit();
+  populateChecks('checks1');
+  populateChecks('checks2');
 });

--- a/home.html
+++ b/home.html
@@ -129,7 +129,7 @@
         <div class="app-icon"><img src="icons/plotting.png" alt="Plotting"></div>
         <span>Plotting</span>
       </a>
-      <a class="dock-btn" href="#">
+      <a class="dock-btn" href="check.html">
         <div class="app-icon"><img src="icons/daily-check.png" alt="Daily Check"></div>
         <span>Daily Check</span>
       </a>


### PR DESCRIPTION
## Summary
- add check.html with three cards for type selection, photo capture, and icons
- import lb_all.css styling in new check.css
- implement check.js for photo previews, dynamic dropdown and icons, and basic submit overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd41fcd2108329912851cb348f8564