### PR TITLE
fix cuti pdf download site param

### DIFF
--- a/cuti.js
+++ b/cuti.js
@@ -233,8 +233,8 @@ function initPdfDownload(){
       if (!user) return Modal.show("Silakan login ulang.", "Autentikasi");
 
       const idToken = await user.getIdToken(true);
-      // site=CutiFilesPDF -> harus terdaftar di Cloud Functions (SHEETS)
-      const url = `${CFN_DOWNLOAD_PDF_URL}?site=CutiFilesPDF`;
+      // site=CUTI_FILESPDF -> harus terdaftar di Cloud Functions (SHEETS)
+      const url = `${CFN_DOWNLOAD_PDF_URL}?site=CUTI_FILESPDF`;
       const res = await fetch(url, { headers: { Authorization: `Bearer ${idToken}` } });
       if (!res.ok){
         const txt = await res.text().catch(()=> "");


### PR DESCRIPTION
## Summary
- fix cuti pdf download to use CUTI_FILESPDF site key matching cloud functions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf90cd03a88329bbbdc06fa9298d58