### PR TITLE
Add roster loading spinner and collapsible vehicle inspection in ACP form

### DIFF
--- a/ACP.css
+++ b/ACP.css
@@ -156,3 +156,15 @@ input, textarea{
   box-shadow:0 16px 40px rgba(0,0,0,.45);
 }
 .photo-sheet img{ display:block; max-width:100%; max-height:calc(92vh - 40px); border-radius:12px; }
+
+/* ===== Kendaraan collapsible card ===== */
+.vehicle-nav{
+  display:flex; align-items:center; gap:8px;
+  width:100%; background:transparent; border:none; padding:0;
+  color:var(--text); font-weight:600; cursor:pointer;
+}
+.vehicle-nav svg{ transition:transform .2s ease; }
+.vehicle-card .veh-body{ display:none; margin-top:12px; }
+.vehicle-card.open .veh-body{ display:block; }
+.vehicle-card.open .vehicle-nav .label{ display:none; }
+.vehicle-card.open .vehicle-nav svg{ transform:rotate(180deg); }

--- a/ACP.html
+++ b/ACP.html
@@ -37,100 +37,88 @@
           <span id="instansi" class="info-value">-</span>
         </div>
       </div>
-    </section>
-
-    <section class="card">
-      <table class="insp-table" aria-label="Daftar Pemeriksaan">
-        <colgroup>
-          <col class="col-area" />
-          <col class="col-status" />
-          <col class="col-img" />
-        </colgroup>
-        <thead>
-          <tr>
-            <th>Tempat<br />Pemeriksaan</th>
-            <th>
-              <span class="status-sample">☑</span> Aman<br />
-              <span class="status-sample">☐</span> Tidak Aman
-            </th>
-            <th>Lihat<br />Gambar</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Bagasi Mobil</td>
-            <td><input type="checkbox" data-area="bagasiMobil" /></td>
-            <td><a href="#" class="img-link" data-img="icons/bagasicar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Bawah Mobil</td>
-            <td><input type="checkbox" data-area="bawahMobil" /></td>
-            <td><a href="#" class="img-link" data-img="icons/bawahcar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Sekitar Roda</td>
-            <td><input type="checkbox" data-area="sekitarRoda" /></td>
-            <td><a href="#" class="img-link" data-img="icons/rodacar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Kantong Pintu</td>
-            <td><input type="checkbox" data-area="kantongPintu" /></td>
-            <td><a href="#" class="img-link" data-img="icons/pintucar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Visor</td>
-            <td><input type="checkbox" data-area="visor" /></td>
-            <td><a href="#" class="img-link" data-img="icons/visorcar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Laci Dashboard</td>
-            <td><input type="checkbox" data-area="laciDashboard" /></td>
-            <td><a href="#" class="img-link" data-img="icons/lacicar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Bawah Kursi</td>
-            <td><input type="checkbox" data-area="bawahKursi" /></td>
-            <td><a href="#" class="img-link" data-img="icons/kursicar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Kap Mobil</td>
-            <td><input type="checkbox" data-area="kapMobil" /></td>
-            <td><a href="#" class="img-link" data-img="icons/kapcar.png">Gambar</a></td>
-          </tr>
-          <tr>
-            <td>Area Lain</td>
-            <td><input type="checkbox" data-area="areaLain" /></td>
-            <td>-</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section class="card">
-      <h1 class="card-title">Input Data ACP</h1>
-
       <div class="field">
         <label for="prohibited">Prohibited Item</label>
         <input id="prohibited" type="text" />
       </div>
-      <div class="field">
-        <label for="lokasi">Lokasi ACP</label>
-        <input id="lokasi" type="text" />
-      </div>
-      <div class="field">
-        <label for="jamMasuk">Jam Masuk</label>
-        <input id="jamMasuk" type="time" />
-      </div>
-      <div class="field">
-        <label for="pemeriksa">Pemeriksa</label>
-        <input id="pemeriksa" type="text" />
-      </div>
-      <div class="field">
-        <label for="supervisor">Supervisor</label>
-        <input id="supervisor" type="text" />
-      </div>
-
       <button id="submitBtn" type="button" class="btn primary full">Kirim Data</button>
+    </section>
+    <input id="lokasi" type="hidden" />
+    <input id="jamMasuk" type="hidden" />
+    <input id="pemeriksa" type="hidden" />
+    <input id="supervisor" type="hidden" />
+
+    <section id="vehicleCard" class="card vehicle-card">
+      <button id="vehToggle" class="vehicle-nav" type="button" aria-expanded="false">
+        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true"><path d="M12 15l-6-6h12z" fill="currentColor" /></svg>
+        <span class="label">Menggunakan Kendaraan</span>
+      </button>
+      <div class="veh-body">
+        <table class="insp-table" aria-label="Daftar Pemeriksaan">
+          <colgroup>
+            <col class="col-area" />
+            <col class="col-status" />
+            <col class="col-img" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Tempat<br />Pemeriksaan</th>
+              <th>
+                <span class="status-sample">☑</span> Aman<br />
+                <span class="status-sample">☐</span> Tidak Aman
+              </th>
+              <th>Lihat<br />Gambar</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Bagasi Mobil</td>
+              <td><input type="checkbox" data-area="bagasiMobil" /></td>
+              <td><a href="#" class="img-link" data-img="icons/bagasicar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Bawah Mobil</td>
+              <td><input type="checkbox" data-area="bawahMobil" /></td>
+              <td><a href="#" class="img-link" data-img="icons/bawahcar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Sekitar Roda</td>
+              <td><input type="checkbox" data-area="sekitarRoda" /></td>
+              <td><a href="#" class="img-link" data-img="icons/rodacar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Kantong Pintu</td>
+              <td><input type="checkbox" data-area="kantongPintu" /></td>
+              <td><a href="#" class="img-link" data-img="icons/pintucar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Visor</td>
+              <td><input type="checkbox" data-area="visor" /></td>
+              <td><a href="#" class="img-link" data-img="icons/visorcar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Laci Dashboard</td>
+              <td><input type="checkbox" data-area="laciDashboard" /></td>
+              <td><a href="#" class="img-link" data-img="icons/lacicar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Bawah Kursi</td>
+              <td><input type="checkbox" data-area="bawahKursi" /></td>
+              <td><a href="#" class="img-link" data-img="icons/kursicar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Kap Mobil</td>
+              <td><input type="checkbox" data-area="kapMobil" /></td>
+              <td><a href="#" class="img-link" data-img="icons/kapcar.png">Gambar</a></td>
+            </tr>
+            <tr>
+              <td>Area Lain</td>
+              <td><input type="checkbox" data-area="areaLain" /></td>
+              <td>-</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   </main>
   <div id="overlay" class="overlay hidden" role="dialog" aria-live="polite" aria-modal="true">


### PR DESCRIPTION
## Summary
- show lb_all-style spinner while fetching roster data to autofill lokasi and supervisor
- move prohibited item input to main card and hide other ACP fields
- add collapsible "Menggunakan Kendaraan" section that defaults closed and posts NIHIL when unused

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check ACP.js`


------
https://chatgpt.com/codex/tasks/task_e_68bff1d4c4d08329949c6485685822c0