### PR TITLE
Avoid redirect loop on logout

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,10 +34,13 @@
   <!-- 1) Router untuk handle deep-link dari 404.html -->
   <script type="module" src="router.js"></script>
 
-  <!-- 2) Auto-redirect kalau sudah login -->
+  <!-- 2) Auto-redirect kalau sudah login (skip saat logout) -->
   <script type="module">
     import { redirectIfAuthed } from "./auth-guard.js";
-    redirectIfAuthed({ homePath: "home.html" });
+    const params = new URLSearchParams(location.search);
+    if (params.get("logout") !== "1") {
+      redirectIfAuthed({ homePath: "home.html" });
+    }
   </script>
 </head>
 <body class="blur-bg">

--- a/login.js
+++ b/login.js
@@ -360,6 +360,7 @@ window.logout = async function(){
     sessionStorage.removeItem("authProfile");
     sessionStorage.removeItem("justSignedIn");
     ok("Berhasil keluar.");
+    history.replaceState(null, "", location.pathname);
     show(welcome);
     Overlay.hide();
   }catch(e){


### PR DESCRIPTION
## Summary
- Skip auto redirect on index.html when `?logout=1` is present
- Clean up URL after logging out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c10f9eb1088329990d2c30ec36b813